### PR TITLE
fix(release): Fix uploading release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,6 @@ jobs:
 
       - name: Deploy server
         env:
-          EXAROTON_TOKEN: secrets.EXAROTON_TOKEN
-          EXAROTON_SERVER_ID: secrets.EXAROTON_SERVER_ID
+          EXAROTON_TOKEN: ${{ secrets.EXAROTON_TOKEN }}
+          EXAROTON_SERVER_ID: ${{ secrets.EXAROTON_SERVER_ID }}
         run: python scripts/deploy.py build/server


### PR DESCRIPTION
Updated the release workflow to use 'gh release upload' for artifact uploads instead of 'softprops/action-gh-release'.